### PR TITLE
Expose task and executable name via `Task` and `Exec` interfaces

### DIFF
--- a/pkg/task/fs/clean/clean.go
+++ b/pkg/task/fs/clean/clean.go
@@ -74,6 +74,11 @@ func (t *Task) Clean() ([]string, error) {
 	return cleaned, nil
 }
 
+// Name returns the task name.
+func (t *Task) Name() string {
+	return t.opts.name
+}
+
 // Options returns the task options.
 func (t *Task) Options() task.Options {
 	return *t.opts

--- a/pkg/task/fs/clean/options.go
+++ b/pkg/task/fs/clean/options.go
@@ -4,8 +4,8 @@
 package clean
 
 const (
-	// TaskName is the name of the task.
-	TaskName = "fs/clean"
+	// taskName is the name of the task.
+	taskName = "fs/clean"
 )
 
 // Option is a task option.
@@ -17,6 +17,9 @@ type Options struct {
 	// allowed.
 	limitToAppOutputDir bool
 
+	// name is the task name.
+	name string
+
 	// paths are paths to remove.
 	// Note that only paths within the configured application output directory are allowed when limitToAppOutputDir is
 	// enabled
@@ -25,7 +28,9 @@ type Options struct {
 
 // NewOptions creates new task options.
 func NewOptions(opts ...Option) (*Options, error) {
-	opt := &Options{}
+	opt := &Options{
+		name: taskName,
+	}
 	for _, o := range opts {
 		o(opt)
 	}

--- a/pkg/task/gofumpt/gofumpt.go
+++ b/pkg/task/gofumpt/gofumpt.go
@@ -77,6 +77,11 @@ func (t *Task) Env() map[string]string {
 	return t.opts.env
 }
 
+// ExecName returns the executable name.
+func (t *Task) ExecName() string {
+	return t.opts.execName
+}
+
 // ID returns the identifier of the Go module.
 func (t *Task) ID() *project.GoModuleID {
 	return t.opts.goModule
@@ -87,6 +92,11 @@ func (t *Task) Kind() task.Kind {
 	return task.KindGoModule
 }
 
+// Name returns the task name.
+func (t *Task) Name() string {
+	return t.opts.execName
+}
+
 // Options returns the task options.
 func (t *Task) Options() task.Options {
 	return *t.opts
@@ -94,6 +104,10 @@ func (t *Task) Options() task.Options {
 
 // New creates a new task for the "mvdan.cc/gofumpt" Go module command.
 //nolint:gocritic // The app.Config struct is passed as value by design to ensure immutability.
-func New(ac app.Config, opts ...Option) *Task {
-	return &Task{ac: ac, opts: NewOptions(opts...)}
+func New(ac app.Config, opts ...Option) (*Task, error) {
+	opt, optErr := NewOptions(opts...)
+	if optErr != nil {
+		return nil, optErr
+	}
+	return &Task{ac: ac, opts: opt}, nil
 }

--- a/pkg/task/gofumpt/options.go
+++ b/pkg/task/gofumpt/options.go
@@ -4,17 +4,26 @@
 package gofumpt
 
 import (
+	"fmt"
+
 	"github.com/Masterminds/semver/v3"
 
 	"github.com/svengreb/wand/pkg/project"
+	"github.com/svengreb/wand/pkg/task"
 )
 
 const (
+	// DefaultExecName is the default name of the module executable.
+	DefaultExecName = "gofumpt"
+
 	// DefaultGoModulePath is the default module import path.
 	DefaultGoModulePath = "mvdan.cc/gofumpt"
 
-	// TaskName is the name of the task.
-	TaskName = "gofumpt"
+	// DefaultGoModuleVersion is the default Go module version of the runner command.
+	DefaultGoModuleVersion = "v0.1.1"
+
+	// taskName is the name of the task.
+	taskName = "gofumpt"
 )
 
 // Option is a task option.
@@ -24,6 +33,9 @@ type Option func(*Options)
 type Options struct {
 	// env is the task specific environment.
 	env map[string]string
+
+	// execName is the unique executable name.
+	execName string
 
 	// extraArgs are additional arguments passed to the command.
 	extraArgs []string
@@ -38,6 +50,9 @@ type Options struct {
 	// listNonCompliantFiles indicates whether files, whose formatting are not conform to the style guide, should be
 	// listed.
 	listNonCompliantFiles bool
+
+	// name is the task name.
+	name string
 
 	// paths are the paths to search for Go source files.
 	// By default all directories are scanned recursively starting from the working directory of the current process.
@@ -54,25 +69,42 @@ type Options struct {
 }
 
 // NewOptions creates new task options.
-func NewOptions(opts ...Option) *Options {
+func NewOptions(opts ...Option) (*Options, error) {
+	version, versionErr := semver.NewVersion(DefaultGoModuleVersion)
+	if versionErr != nil {
+		return nil, &task.ErrTask{
+			Err:  fmt.Errorf("parsing default module version %q: %w", DefaultGoModulePath, versionErr),
+			Kind: task.ErrInvalidTaskOpts,
+		}
+	}
+
 	opt := &Options{
 		env: make(map[string]string),
+		execName: DefaultExecName,
 		goModule: &project.GoModuleID{
 			Path:     DefaultGoModulePath,
-			IsLatest: true,
+			Version: version,
 		},
+		name: taskName,
 	}
 	for _, o := range opts {
 		o(opt)
 	}
 
-	return opt
+	return opt, nil
 }
 
 // WithEnv sets the task specific environment.
 func WithEnv(env map[string]string) Option {
 	return func(o *Options) {
 		o.env = env
+	}
+}
+
+// WithExecName sets the name of the executable.
+func WithExecName(execName string) Option {
+	return func(o *Options) {
+		o.execName = execName
 	}
 }
 

--- a/pkg/task/goimports/goimports.go
+++ b/pkg/task/goimports/goimports.go
@@ -77,6 +77,11 @@ func (t *Task) Env() map[string]string {
 	return t.opts.env
 }
 
+// ExecName returns the executable name.
+func (t *Task) ExecName() string {
+	return t.opts.execName
+}
+
 // ID returns the identifier of the Go module.
 func (t *Task) ID() *project.GoModuleID {
 	return t.opts.goModule
@@ -85,6 +90,11 @@ func (t *Task) ID() *project.GoModuleID {
 // Kind returns the task kind.
 func (t *Task) Kind() task.Kind {
 	return task.KindGoModule
+}
+
+// Name returns the task name.
+func (t *Task) Name() string {
+	return t.opts.name
 }
 
 // Options returns the task options.

--- a/pkg/task/golang/build/build.go
+++ b/pkg/task/golang/build/build.go
@@ -53,6 +53,11 @@ func (t *Task) Kind() task.Kind {
 	return task.KindExec
 }
 
+// Name returns the task name.
+func (t *Task) Name() string {
+	return t.opts.name
+}
+
 // Options returns the task options.
 func (t *Task) Options() task.Options {
 	return *t.opts

--- a/pkg/task/golang/build/options.go
+++ b/pkg/task/golang/build/options.go
@@ -11,8 +11,8 @@ const (
 	// DefaultDistOutputDirName is the default directory name for production and distribution builds.
 	DefaultDistOutputDirName = "dist"
 
-	// TaskName is the name of the task.
-	TaskName = "go/build"
+	// taskName is the name of the task.
+	taskName = "go/build"
 )
 
 // Option is a task option.
@@ -37,6 +37,9 @@ type Options struct {
 	//   - https://golang.org/cmd/go/#hdr-Compile_packages_and_dependencies
 	Flags []string
 
+	// name is the task name.
+	name string
+
 	// OutputDir is the output directory, relative to the project root, for compilation artifacts.
 	OutputDir string
 
@@ -46,7 +49,9 @@ type Options struct {
 
 // NewOptions creates new task options.
 func NewOptions(opts ...Option) *Options {
-	opt := &Options{}
+	opt := &Options{
+		name: taskName,
+	}
 	for _, o := range opts {
 		o(opt)
 	}

--- a/pkg/task/golang/install/install.go
+++ b/pkg/task/golang/install/install.go
@@ -1,3 +1,5 @@
+// +build go1.16
+
 // Copyright (c) 2019-present Sven Greb <development@svengreb.de>
 // This source code is licensed under the MIT license found in the LICENSE file.
 
@@ -57,6 +59,11 @@ func (t *Task) Kind() task.Kind {
 	return task.KindExec
 }
 
+// Name returns the task name.
+func (t *Task) Name() string {
+	return t.opts.name
+}
+
 // Options returns the task options.
 func (t *Task) Options() task.Options {
 	return *t.opts
@@ -64,11 +71,6 @@ func (t *Task) Options() task.Options {
 
 // New creates a new task for the Go toolchain "install" command.
 //nolint:gocritic // The app.Config struct is passed as value by design to ensure immutability.
-func New(ac app.Config, opts ...Option) (*Task, error) {
-	opt, optErr := NewOptions(opts...)
-	if optErr != nil {
-		return nil, optErr
-	}
-
-	return &Task{ac: ac, opts: opt}, nil
+func New(ac app.Config, opts ...Option) *Task {
+	return &Task{ac: ac, opts: NewOptions(opts...)}
 }

--- a/pkg/task/golang/install/options.go
+++ b/pkg/task/golang/install/options.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	// TaskName is the name of the task.
-	TaskName = "go/install"
+	// taskName is the name of the task.
+	taskName = "go/install"
 )
 
 // Option is a task option.
@@ -24,12 +24,16 @@ type Options struct {
 
 	// goModule is the Go module identifier.
 	goModule *project.GoModuleID
+
+	// name is the task name.
+	name string
 }
 
 // NewOptions creates new task options.
-func NewOptions(opts ...Option) (*Options, error) {
+func NewOptions(opts ...Option) *Options {
 	opt := &Options{
 		goModule: &project.GoModuleID{},
+		name: taskName,
 	}
 	for _, o := range opts {
 		o(opt)
@@ -39,7 +43,7 @@ func NewOptions(opts ...Option) (*Options, error) {
 		opt.goModule.IsLatest = true
 	}
 
-	return opt, nil
+	return opt
 }
 
 // WithEnv sets the task specific environment.

--- a/pkg/task/golang/test/options.go
+++ b/pkg/task/golang/test/options.go
@@ -32,8 +32,8 @@ const (
 	// DefaultTraceProfileOutputFileName is the default file name for the execution trace profile file.
 	DefaultTraceProfileOutputFileName = "trace_profile.out"
 
-	// TaskName is the name of the task.
-	TaskName = "go/test"
+	// taskName is the name of the task.
+	taskName = "go/test"
 )
 
 // Option is a task option.
@@ -128,6 +128,9 @@ type Options struct {
 	//   - https://golang.org/cmd/go/#hdr-Testing_flags
 	MutexProfileOutputFileName string
 
+	// name is the task name.
+	name string
+
 	// OutputDir is the output directory, relative to the project root, for reports like
 	// coverage or benchmark profiles.
 	//
@@ -159,6 +162,7 @@ func NewOptions(opts ...Option) *Options {
 		CPUProfileOutputFileName:      DefaultCPUProfileOutputFileName,
 		MemoryProfileOutputFileName:   DefaultMemoryProfileOutputFileName,
 		MutexProfileOutputFileName:    DefaultMutexProfileOutputFileName,
+		name: taskName,
 		TraceProfileOutputFileName:    DefaultTraceProfileOutputFileName,
 	}
 	for _, o := range opts {

--- a/pkg/task/golang/test/test.go
+++ b/pkg/task/golang/test/test.go
@@ -108,6 +108,11 @@ func (t *Task) Kind() task.Kind {
 	return task.KindExec
 }
 
+// Name returns the unique task name.
+func (t *Task) Name() string {
+	return t.opts.name
+}
+
 // Options returns the task options.
 func (t *Task) Options() task.Options {
 	return *t.opts

--- a/pkg/task/golangcilint/golangcilint.go
+++ b/pkg/task/golangcilint/golangcilint.go
@@ -32,6 +32,11 @@ func (t *Task) Env() map[string]string {
 	return t.opts.env
 }
 
+// ExecName returns the executable name.
+func (t *Task) ExecName() string {
+	return t.opts.execName
+}
+
 // ID returns the identifier of the Go module.
 func (t *Task) ID() *project.GoModuleID {
 	return t.opts.goModule
@@ -40,6 +45,11 @@ func (t *Task) ID() *project.GoModuleID {
 // Kind returns the task kind.
 func (t *Task) Kind() task.Kind {
 	return task.KindGoModule
+}
+
+// Name returns the task name.
+func (t *Task) Name() string {
+	return t.opts.name
 }
 
 // Options returns the task options.

--- a/pkg/task/golangcilint/options.go
+++ b/pkg/task/golangcilint/options.go
@@ -13,14 +13,17 @@ import (
 )
 
 const (
+	// DefaultExecName is the default name of the module executable.
+	DefaultExecName = "golangci-lint"
+
 	// DefaultGoModulePath is the default module import path.
 	DefaultGoModulePath = "github.com/golangci/golangci-lint/cmd/golangci-lint"
 
 	// DefaultGoModuleVersion is the default module version.
 	DefaultGoModuleVersion = "v1.32.0"
 
-	// TaskName is the name of the task.
-	TaskName = "golangcilint"
+	// taskName is the name of the task.
+	taskName = "golangcilint"
 )
 
 // DefaultArgs are default arguments passed to the command.
@@ -37,8 +40,14 @@ type Options struct {
 	// env is the task specific environment.
 	env map[string]string
 
+	// execName is the unique executable name.
+	execName string
+
 	// goModule is the Go module identifier.
 	goModule *project.GoModuleID
+
+	// name is the task name.
+	name string
 
 	// verbose indicates whether the output should be verbose.
 	verbose bool
@@ -56,10 +65,12 @@ func NewOptions(opts ...Option) (*Options, error) {
 
 	opt := &Options{
 		env: make(map[string]string),
+		execName: DefaultExecName,
 		goModule: &project.GoModuleID{
 			Path:    DefaultGoModulePath,
 			Version: version,
 		},
+		name: taskName,
 	}
 	for _, o := range opts {
 		o(opt)
@@ -84,6 +95,13 @@ func WithArgs(args ...string) Option {
 func WithEnv(env map[string]string) Option {
 	return func(o *Options) {
 		o.env = env
+	}
+}
+
+// WithExecName sets the name of the executable.
+func WithExecName(execName string) Option {
+	return func(o *Options) {
+		o.execName = execName
 	}
 }
 

--- a/pkg/task/gox/gox.go
+++ b/pkg/task/gox/gox.go
@@ -71,6 +71,11 @@ func (t *Task) Env() map[string]string {
 	return t.opts.env
 }
 
+// ExecName returns the executable name.
+func (t *Task) ExecName() string {
+	return t.opts.execName
+}
+
 // ID returns the identifier of the Go module.
 func (t *Task) ID() *project.GoModuleID {
 	return t.opts.goModule
@@ -79,6 +84,11 @@ func (t *Task) ID() *project.GoModuleID {
 // Kind returns the task kind.
 func (t *Task) Kind() task.Kind {
 	return task.KindGoModule
+}
+
+// Name returns the task name.
+func (t *Task) Name() string {
+	return t.opts.name
 }
 
 // Options returns the task options.

--- a/pkg/task/gox/options.go
+++ b/pkg/task/gox/options.go
@@ -15,14 +15,17 @@ import (
 )
 
 const (
+	// DefaultExecName is the default name of the module executable.
+	DefaultExecName = "gox"
+
 	// DefaultGoModulePath is the default module import path.
 	DefaultGoModulePath = "github.com/mitchellh/gox"
 
 	// DefaultGoModuleVersion is the default module version.
 	DefaultGoModuleVersion = "v1.0.1"
 
-	// TaskName is the name of the task.
-	TaskName = "gox"
+	// taskName is the name of the task.
+	taskName = "gox"
 )
 
 var (
@@ -52,11 +55,17 @@ type Options struct {
 	// env is the task specific environment.
 	env map[string]string
 
+	// execName is the unique executable name.
+	execName string
+
 	// goCmd is the path to the Go toolchain executable.
 	goCmd string
 
 	// goModule is the Go module identifier.
 	goModule *project.GoModuleID
+
+	// name is the task name.
+	name string
 
 	// outputTemplate is the name template for cross-compile platform targets.
 	outputTemplate string
@@ -83,10 +92,12 @@ func NewOptions(opts ...Option) (*Options, error) {
 
 	opt := &Options{
 		env: make(map[string]string),
+		execName: DefaultExecName,
 		goModule: &project.GoModuleID{
 			Path:    DefaultGoModulePath,
 			Version: version,
 		},
+		name: taskName,
 	}
 	for _, o := range opts {
 		o(opt)
@@ -113,6 +124,13 @@ func NewOptions(opts ...Option) (*Options, error) {
 func WithEnv(env map[string]string) Option {
 	return func(o *Options) {
 		o.env = env
+	}
+}
+
+// WithExecName sets the name of the executable.
+func WithExecName(execName string) Option {
+	return func(o *Options) {
+		o.execName = execName
 	}
 }
 

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -24,6 +24,9 @@ type Exec interface {
 
 	// Env returns the task specific environment.
 	Env() map[string]string
+
+	// ExecName returns the executable name.
+	ExecName() string
 }
 
 // GoModule is a task for a Go module command.
@@ -42,6 +45,9 @@ type GoModule interface {
 type Task interface {
 	// Kind returns the task kind.
 	Kind() Kind
+
+	// Name returns the task name.
+	Name() string
 
 	// Options returns the task options.
 	Options() Options


### PR DESCRIPTION
Resolves #79 