### PR TITLE
Replace deprecated `gobin` with custom `go install` based task runner

### DIFF
--- a/examples/custom_runner/runners.go
+++ b/examples/custom_runner/runners.go
@@ -53,7 +53,7 @@ func (r *FruitMixerRunner) Handles() task.Kind {
 // Run runs the command.
 // It returns an error of type *task.ErrRunner when any error occurs during the command execution.
 func (r *FruitMixerRunner) Run(t task.Task) error {
-	tExec, tErr := r.runPrepare(t)
+	tExec, tErr := r.prepareTask(t)
 	if tErr != nil {
 		return tErr
 	}
@@ -67,7 +67,7 @@ func (r *FruitMixerRunner) Run(t task.Task) error {
 // RunOut runs the command and returns its output.
 // It returns an error of type *task.ErrRunner when any error occurs during the command execution.
 func (r *FruitMixerRunner) RunOut(t task.Task) (string, error) {
-	tExec, tErr := r.runPrepare(t)
+	tExec, tErr := r.prepareTask(t)
 	if tErr != nil {
 		return "", tErr
 	}
@@ -102,8 +102,8 @@ func (r *FruitMixerRunner) Validate() error {
 	return nil
 }
 
-// runPrepare checks if the given task is of type task.Exec and prepares the task specific environment.
-func (r *FruitMixerRunner) runPrepare(t task.Task) (task.Exec, error) {
+// prepareTask checks if the given task is of type task.Exec and prepares the task specific environment.
+func (r *FruitMixerRunner) prepareTask(t task.Task) (task.Exec, error) {
 	tExec, ok := t.(task.Exec)
 	if t.Kind() != task.KindExec || !ok {
 		return nil, &task.ErrRunner{

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,12 @@
 module github.com/svengreb/wand
 
-go 1.15
+go 1.16
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/imdario/mergo v0.3.12
 	github.com/magefile/mage v1.11.0
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/stretchr/testify v1.7.0
 	github.com/svengreb/golib v0.1.0
 	github.com/svengreb/nib v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,3 @@
-github.com/Masterminds/semver/v3 v3.1.0 h1:Y2lUDsFKVRSYGojLJ1yLxSXdMmMYTYls0rCvoqmMUQk=
 github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
@@ -16,7 +15,6 @@ github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
-github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
@@ -30,7 +28,6 @@ github.com/go-git/go-git/v5 v5.2.0 h1:YPBLG/3UK1we1ohRkncLjaXWLW+HKp5QNM/jTli2Jg
 github.com/go-git/go-git/v5 v5.2.0/go.mod h1:kh02eMX+wdqqxgNMEyq8YgwlIOsDOa9homkUq1PoTMs=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
-github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
@@ -54,15 +51,15 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -97,7 +94,6 @@ gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/support/exec/exec.go
+++ b/internal/support/exec/exec.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2019-present Sven Greb <development@svengreb.de>
+// This source code is licensed under the MIT license found in the LICENSE file.
+
+package exec
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	glFS "github.com/svengreb/golib/pkg/io/fs"
+
+	taskGo "github.com/svengreb/wand/pkg/task/golang"
+)
+
+// GetGoExecPath looks up the executable search path(s) of the current environment for the Go executable with the given
+// name. It looks up the paths defined in the system "PATH" environment variable and continues with the Go specific
+// "GOBIN" path.
+// See https://pkg.go.dev/cmd/go#hdr-Environment_variables for more details about Go specific environment variables.
+func GetGoExecPath(name string) (string, error) {
+	// Look up the system executable search path(s)...
+	execPath, pathErr := exec.LookPath(name)
+	os.Environ()
+
+	// ...and continue with the Go specific executable search path.
+	if pathErr != nil {
+		var execDir string
+
+		if execDir = os.Getenv(taskGo.DefaultEnvVarGOBIN); execDir == "" {
+			if execDir = os.Getenv(taskGo.DefaultEnvVarGOPATH); execDir != "" {
+				execDir = filepath.Join(execDir, taskGo.DefaultGOBINSubDirName)
+			}
+		}
+
+		execPath = filepath.Join(execDir, name)
+		execExits, fsErr := glFS.RegularFileExists(execPath)
+		if fsErr != nil {
+			return "", fmt.Errorf("check if %q exists: %w", execPath, fsErr)
+		}
+
+		if !execExits {
+			return "", fmt.Errorf("%q not found in executable search path(s): %v", name, append(os.Environ(), execDir))
+		}
+	}
+
+	return execPath, nil
+}

--- a/pkg/elder/gitignore.tmpl
+++ b/pkg/elder/gitignore.tmpl
@@ -1,0 +1,2 @@
+# Do not track cached data like compiled executables of Go module-based "main" packages.
+cache/

--- a/pkg/project/options.go
+++ b/pkg/project/options.go
@@ -22,6 +22,12 @@ const (
 	// and production artifacts as well as distribution bundles, static web files or metric/statistic reports.
 	DefaultBaseOutputDir = "out"
 
+	// DefaultWandCacheDataDir is the default directory for wand specific cache data.
+	DefaultWandCacheDataDir = "cache"
+
+	// DefaultWandDir is the default directory for wand specific data.
+	DefaultWandDir = ".wand"
+
 	// DefaultVersion is the default version for a project vcs.Repository.
 	DefaultVersion = "v0.0.0"
 )
@@ -52,6 +58,9 @@ type Options struct {
 
 	// VCSKind is the VCS kind of the project Repository.
 	VCSKind vcs.Kind
+
+	// WandDataDir is the path to the directory for wand specific data.
+	WandDataDir string
 }
 
 // Option is a project option.
@@ -110,6 +119,13 @@ func WithVCSKind(kind vcs.Kind) Option {
 	}
 }
 
+// WithWandDataDir sets the path to the directory for wand specific data.
+func WithWandDataDir(wandDataDir string) Option {
+	return func(o *Options) {
+		o.WandDataDir = wandDataDir
+	}
+}
+
 // newOptions creates new project options.
 // The absolute path to the root directory is automatically set based on the current working directory and the Go module
 // name is automatically determined using the runtime/debug package.
@@ -144,6 +160,7 @@ func newOptions(opts ...Option) (*Options, error) {
 		Repository:     vcsNone.New(),
 		RootDirPathAbs: rootDirPath,
 		VCSKind:        vcs.KindNone,
+		WandDataDir:    filepath.Join(rootDirPath, DefaultWandDir),
 	}
 	for _, o := range opts {
 		o(opt)

--- a/pkg/task/fs/clean/clean.go
+++ b/pkg/task/fs/clean/clean.go
@@ -86,11 +86,6 @@ func (t *Task) Options() task.Options {
 
 // New creates a new task.
 //nolint:gocritic // The app.Config struct is passed as value by design to ensure immutability.
-func New(proj project.Metadata, ac app.Config, opts ...Option) (*Task, error) {
-	opt, optErr := NewOptions(opts...)
-	if optErr != nil {
-		return nil, fmt.Errorf("create %q task options: %w", taskName, optErr)
-	}
-
-	return &Task{ac: ac, proj: proj, opts: opt}, nil
+func New(proj project.Metadata, ac app.Config, opts ...Option) *Task {
+	return &Task{ac: ac, proj: proj, opts: NewOptions(opts...)}
 }

--- a/pkg/task/fs/clean/options.go
+++ b/pkg/task/fs/clean/options.go
@@ -27,7 +27,7 @@ type Options struct {
 }
 
 // NewOptions creates new task options.
-func NewOptions(opts ...Option) (*Options, error) {
+func NewOptions(opts ...Option) *Options {
 	opt := &Options{
 		name: taskName,
 	}
@@ -35,7 +35,7 @@ func NewOptions(opts ...Option) (*Options, error) {
 		o(opt)
 	}
 
-	return opt, nil
+	return opt
 }
 
 // WithLimitToAppOutputDir indicates whether only paths within the configured application output directory should be

--- a/pkg/task/golang/install/install.go
+++ b/pkg/task/golang/install/install.go
@@ -1,7 +1,7 @@
-// +build go1.16
-
 // Copyright (c) 2019-present Sven Greb <development@svengreb.de>
 // This source code is licensed under the MIT license found in the LICENSE file.
+
+// +build go1.16
 
 // Package install provides a task for the Go toolchain "install" command.
 // It requires at least Go version 1.16 which comes with support to install commands via `go install` (1) without

--- a/pkg/task/gotool/gotool.go
+++ b/pkg/task/gotool/gotool.go
@@ -1,0 +1,335 @@
+// Copyright (c) 2019-present Sven Greb <development@svengreb.de>
+// This source code is licensed under the MIT license found in the LICENSE file.
+
+// +build go1.16
+
+// Package gotool provides a runner to install and run compiled executables of Go module-based "main" packages.
+//
+// Go Executable Installation
+//
+// As of Go 1.16 `go install` supports the `pkg@version` syntax [1] which allows to install commands without "polluting"
+// a projects `go.mod` file. The resulting executables are placed in the Go executable search path that is defined by
+// the "GOBIN" environment variable [2] (see the "go env" command [3] to show or modify the Go toolchain environment).
+// The problem is that installed executables will overwrite any previously installed executable of the same
+// module/package regardless of the version. Therefore only one version of an executable can be installed at a time
+// which makes it impossible to work on different projects that make use of the same executable but require different
+// versions.
+//
+// UX Before Go 1.16
+//
+// The installation concept for "main" package executables was always a somewhat controversial point which
+// unfortunately, partly for historical reasons, did not offer an optimal and user-friendly solution until Go 1.16.
+// The "go" command [4] is a fantastic toolchain that provides many great features one would expect to be provided
+// out-of-the-box from a modern and well designed programming language without the requirement to use a third-party
+// solution: from compiling code, running unit/integration/benchmark tests, quality and error analysis, debugging
+// utilities and many more.
+// This did not apply for the "go install" command [1] of Go versions less than 1.16.
+//
+// The general problem of tool dependencies was a long-time known issue/weak point of the Go toolchain and was a highly
+// rated change request from the Go community with discussions like https://github.com/golang/go/issues/30515,
+// https://github.com/golang/go/issues/25922 and https://github.com/golang/go/issues/27653 to improve this essential
+// feature. They have been around for quite a long time without a solution that worked without introducing breaking
+// changes and most users and the Go team agree on.
+// Luckily, this topic was finally resolved in the Go release version 1.16 [5] and
+// https://github.com/golang/go/issues/40276 introduced a way to install executables in module mode outside a module.
+//
+// The Leftover Drawback
+//
+// Even though the "go install" command works totally fine to globally install executables, the problem that only a
+// single version can be installed at a time is still left. The executable is placed in the path defined by
+// "go env GOBIN" so the previously installed executable will be overridden. It is not possible to install multiple
+// versions of the same package and "go install" still messes up the local user environment.
+//
+// The Workaround
+//
+// To work around the leftover drawback, this package provides a runner that uses "go install" under the
+// hood, but allows to place the compiled executable in a custom cache directory instead of `go env GOBIN`. It checks if the
+// executable already exists, installs it if not so, and executes it afterwards.
+//
+// The concept of storing dependencies locally on a per-project basis is well-known from the "node_modules"
+// directory [6] of the Node [7] package manager npm [8]. Storing executables in a cache directory within the
+// repository (not tracked by Git) allows to use "go install" mechanisms while not affect the global user environment
+// and executables stored in "go env GOBIN".
+// The runner achieves this by temporarily changing the "GOBIN" environment variable to the custom cache directory
+// during the execution of "go install".
+//
+// The only known disadvantage is the increased usage of storage disk space, but since most Go executables are small in
+// size anyway, this is perfectly acceptable compared to the clearly outweighing advantages.
+//
+// Note that the runner dynamically runs executables based on the given task so the "Validate" method is a NOOP.
+//
+// Future Changes
+//
+// The provided runner is still not a clean solution that uses the Go toolchain without any special logic so as soon as
+// the following changes are made to the Go toolchain (Go 1.17 or later), the runner will be removed again:
+//
+// - https://github.com/golang/go/issues/42088 tracks the process of adding support for the Go module syntax to the
+//   "go run" command. This will allow to let the Go toolchain handle the way how compiled executable are stored,
+//   located and executed.
+// - https://github.com/golang/go/issues/44469#issuecomment-784534876 tracks the process of making "go install" aware of
+//   the "-o" flag like the "go build" command which is the only reason why the provided runner exists.
+//
+// References
+//
+//   [1]: https://pkg.go.dev/cmd/go#hdr-Compile_and_install_packages_and_dependencies
+//   [2]: https://pkg.go.dev/cmd/go/#hdr-Environment_variables
+//   [3]: https://pkg.go.dev/cmd/go/#hdr-Print_Go_environment_information
+//   [4]: https://pkg.go.dev/cmd/go
+//   [5]: https://golang.org/doc/go1.16#modules
+//   [6]: https://docs.npmjs.com/cli/v7/configuring-npm/folders#node-modules
+//   [7]: https://nodejs.org
+//   [8]: https://www.npmjs.com
+package gotool
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/magefile/mage/sh"
+	glFS "github.com/svengreb/golib/pkg/io/fs"
+
+	osSupport "github.com/svengreb/wand/internal/support/os"
+	"github.com/svengreb/wand/pkg/project"
+	"github.com/svengreb/wand/pkg/task"
+	taskGo "github.com/svengreb/wand/pkg/task/golang"
+	taskGoInstall "github.com/svengreb/wand/pkg/task/golang/install"
+)
+
+// Runner is runner to install and run compiled executables of Go module-based "main" packages.
+//
+// Go Executable Installation
+//
+// As of Go 1.16 `go install` supports the `pkg@version` syntax [1] which allows to install commands without "polluting"
+// a projects `go.mod` file. The resulting executables are placed in the Go executable search path that is defined by
+// the "GOBIN" environment variable [2] (see the "go env" command [3] to show or modify the Go toolchain environment).
+// The problem is that installed executables will overwrite any previously installed executable of the same
+// module/package regardless of the version. Therefore only one version of an executable can be installed at a time
+// which makes it impossible to work on different projects that make use of the same executable but require different
+// versions.
+//
+// UX Before Go 1.16
+//
+// The installation concept for "main" package executables was always a somewhat controversial point which
+// unfortunately, partly for historical reasons, did not offer an optimal and user-friendly solution until Go 1.16.
+// The "go" command [4] is a fantastic toolchain that provides many great features one would expect to be provided
+// out-of-the-box from a modern and well designed programming language without the requirement to use a third-party
+// solution: from compiling code, running unit/integration/benchmark tests, quality and error analysis, debugging
+// utilities and many more.
+// This did not apply for the "go install" command [1] of Go versions less than 1.16.
+//
+// The general problem of tool dependencies was a long-time known issue/weak point of the Go toolchain and was a highly
+// rated change request from the Go community with discussions like https://github.com/golang/go/issues/30515,
+// https://github.com/golang/go/issues/25922 and https://github.com/golang/go/issues/27653 to improve this essential
+// feature. They have been around for quite a long time without a solution that worked without introducing breaking
+// changes and most users and the Go team agree on.
+// Luckily, this topic was finally resolved in the Go release version 1.16 [5] and
+// https://github.com/golang/go/issues/40276 introduced a way to install executables in module mode outside a module.
+//
+// The Leftover Drawback
+//
+// Even though the "go install" command works totally fine to globally install executables, the problem that only a
+// single version can be installed at a time is still left. The executable is placed in the path defined by
+// "go env GOBIN" so the previously installed executable will be overridden. It is not possible to install multiple
+// versions of the same package and "go install" still messes up the local user environment.
+//
+// The Workaround
+//
+// To work around the leftover drawback, this runner uses "go install" under the hood, but allows to place the compiled
+// executable in a custom cache directory instead of `go env GOBIN`. It checks if the executable already exists,
+// installs it if not so, and executes it afterwards.
+//
+// The concept of storing dependencies locally on a per-project basis is well-known from the "node_modules"
+// directory [6] of the Node [7] package manager npm [8]. Storing executables in a cache directory within the
+// repository (not tracked by Git) allows to use "go install" mechanisms while not affect the global user environment
+// and executables stored in "go env GOBIN".
+// The runner achieves this by temporarily changing the "GOBIN" environment variable to the custom cache directory
+// during the execution of "go install".
+//
+// The only known disadvantage is the increased usage of storage disk space, but since most Go executables are small in
+// size anyway, this is perfectly acceptable compared to the clearly outweighing advantages.
+//
+// Note that the runner dynamically runs executables based on the given task so the "Validate" method is a NOOP.
+//
+// Future Changes
+//
+// This runner is still not a clean solution that uses the Go toolchain without any special logic so as soon as the
+// following changes are made to the Go toolchain (Go 1.17 or later), the runner will be removed again:
+//
+// - https://github.com/golang/go/issues/42088 tracks the process of adding support for the Go module syntax to the
+//   "go run" command. This will allow to let the Go toolchain handle the way how compiled executable are stored,
+//   located and executed.
+// - https://github.com/golang/go/issues/44469#issuecomment-784534876 tracks the process of making "go install" aware of
+//   the "-o" flag like the "go build" command which is the only reason why this runner exists.
+//
+// References
+//
+//   [1]: https://pkg.go.dev/cmd/go#hdr-Compile_and_install_packages_and_dependencies
+//   [2]: https://pkg.go.dev/cmd/go/#hdr-Environment_variables
+//   [3]: https://pkg.go.dev/cmd/go/#hdr-Print_Go_environment_information
+//   [4]: https://pkg.go.dev/cmd/go
+//   [5]: https://golang.org/doc/go1.16#modules
+//   [6]: https://docs.npmjs.com/cli/v7/configuring-npm/folders#node-modules
+//   [7]: https://nodejs.org
+//   [8]: https://www.npmjs.com
+type Runner struct {
+	goRunner *taskGo.Runner
+	opts     *RunnerOptions
+}
+
+// Handles returns the supported task kind.
+func (r *Runner) Handles() task.Kind {
+	return task.KindGoModule
+}
+
+// Install installs the executable of the given Go module.
+// It returns an error of type *task.ErrRunner when any error occurs during the command execution.
+//
+// // See https://pkg.go.dev/cmd/go#hdr-Compile_and_install_packages_and_dependencies for more details.
+func (r *Runner) Install(goModule *project.GoModuleID) error {
+	_, err := r.prepareExec(goModule)
+	if err != nil {
+		return &task.ErrRunner{
+			Err:  fmt.Errorf("runner %q: %w", RunnerName, err),
+			Kind: task.ErrRun,
+		}
+	}
+
+	return nil
+}
+
+// Run runs the command.
+// It returns an error of type *task.ErrRunner when any error occurs during the command execution.
+func (r *Runner) Run(t task.Task) error {
+	tGM, tErr := r.prepareTask(t)
+	if tErr != nil {
+		return fmt.Errorf("runner %q: %w", RunnerName, tErr)
+	}
+
+	execPath, preExecErr := r.prepareExec(tGM.ID())
+	if preExecErr != nil {
+		return &task.ErrRunner{
+			Err:  fmt.Errorf("runner %q: %w", RunnerName, preExecErr),
+			Kind: task.ErrRunnerValidation,
+		}
+	}
+
+	if r.opts.Quiet {
+		return sh.RunWith(r.opts.Env, execPath, tGM.BuildParams()...)
+	}
+	return sh.RunWithV(r.opts.Env, execPath, tGM.BuildParams()...)
+}
+
+// RunOut runs the command and returns its output.
+// It returns an error of type *task.ErrRunner when any error occurs during the command execution.
+func (r *Runner) RunOut(t task.Task) (string, error) {
+	tGM, tErr := r.prepareTask(t)
+	if tErr != nil {
+		return "", fmt.Errorf("runner %q: %w", RunnerName, tErr)
+	}
+
+	execPath, preExecErr := r.prepareExec(tGM.ID())
+	if preExecErr != nil {
+		return "", &task.ErrRunner{
+			Err:  fmt.Errorf("runner %q: %w", RunnerName, preExecErr),
+			Kind: task.ErrRunnerValidation,
+		}
+	}
+
+	return sh.OutputWith(r.opts.Env, execPath, tGM.BuildParams()...)
+}
+
+// Validate validates the runner.
+// This runner uses dynamic executables based on the given task so this method is a NOOP.
+func (r *Runner) Validate() error {
+	return nil
+}
+
+// buildExecDir builds and returns the path to the directory for the executable.
+func (r *Runner) buildExecDir(goModule *project.GoModuleID) string {
+	path := filepath.Join(r.opts.toolsBinDir, goModule.ExecName())
+
+	if goModule.Version != nil && !goModule.IsLatest {
+		return filepath.Join(path, goModule.Version.String())
+	}
+
+	return filepath.Join(path, project.GoModuleVersionLatest)
+}
+
+// install installs the compiled executable of a Go module-based "main" package.
+// It returns an error of type *task.ErrRunner when any error occurs during the installation.
+func (r *Runner) install(execDir string, goModule *project.GoModuleID) error {
+	env := osSupport.EnvSliceToMap(os.Environ())
+	for k, v := range r.opts.Env {
+		env[k] = v
+	}
+	// Override the "GOBIN" environment variable to use the given path for the compiled executable.
+	env[taskGo.DefaultEnvVarGOBIN] = execDir
+
+	t := taskGoInstall.New(
+		taskGoInstall.WithModulePath(goModule.Path),
+		taskGoInstall.WithModuleVersion(goModule.Version),
+		taskGoInstall.WithEnv(env),
+	)
+
+	if err := r.goRunner.Run(t); err != nil {
+		return fmt.Errorf("run %q: %w", t.Name(), err)
+	}
+
+	return nil
+}
+
+// prepareExec prepares the ensure that the executable exists and returns the path.
+func (r *Runner) prepareExec(goModule *project.GoModuleID) (string, error) {
+	execDir := r.buildExecDir(goModule)
+	execPath := filepath.Join(execDir, goModule.ExecName())
+
+	exists, fsErr := glFS.RegularFileExists(execPath)
+	if fsErr != nil {
+		return "", fmt.Errorf("check executable %q: %w", execPath, fsErr)
+	}
+
+	if !exists {
+		if err := os.MkdirAll(execDir, os.ModePerm); err != nil {
+			return "", fmt.Errorf("create directory structure %q for execuable: %w", execDir, err)
+		}
+
+		if err := r.install(execDir, goModule); err != nil {
+			return "", fmt.Errorf("install executable %q: %w", execPath, err)
+		}
+	}
+
+	return execPath, nil
+}
+
+// prepareTask checks if the given task is of type task.GoModule and prepares the task specific environment.
+// It returns an error of type *task.ErrRunner when any error occurs during the execution.
+func (r *Runner) prepareTask(t task.Task) (task.GoModule, error) {
+	tGM, ok := t.(task.GoModule)
+	if t.Kind() != task.KindGoModule || !ok {
+		return nil, &task.ErrRunner{
+			Err:  fmt.Errorf("expected %q but got %q", r.Handles(), t.Kind()),
+			Kind: task.ErrUnsupportedTaskKind,
+		}
+	}
+
+	for k, v := range tGM.Env() {
+		r.opts.Env[k] = v
+	}
+
+	return tGM, nil
+}
+
+// NewRunner creates a new command runner for Go module-based tools.
+// It returns an error of type *task.ErrRunner when any error occurs during the creation.
+func NewRunner(goRunner *taskGo.Runner, opts ...RunnerOption) (*Runner, error) {
+	opt, optErr := NewRunnerOptions(opts...)
+	if optErr != nil {
+		return nil, &task.ErrRunner{
+			Err:  fmt.Errorf("create %q runner options: %w", RunnerName, optErr),
+			Kind: task.ErrInvalidRunnerOpts,
+		}
+	}
+
+	return &Runner{goRunner: goRunner, opts: opt}, nil
+}

--- a/pkg/task/gotool/options.go
+++ b/pkg/task/gotool/options.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2019-present Sven Greb <development@svengreb.de>
+// This source code is licensed under the MIT license found in the LICENSE file.
+
+package gotool
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+const (
+	// RunnerName is the name of the runner.
+	RunnerName = "gotool"
+)
+
+// RunnerOption is a runner option.
+type RunnerOption func(*RunnerOptions)
+
+// RunnerOptions are runner options.
+type RunnerOptions struct {
+	// Env is the runner specific environment.
+	Env map[string]string
+
+	// toolsBinDir is the path to the directory where compiled executables of Go module-based "main" packages are placed.
+	toolsBinDir string
+
+	// Quiet indicates whether the runner output should be minimal.
+	Quiet bool
+}
+
+// NewRunnerOptions creates new runner options.
+func NewRunnerOptions(opts ...RunnerOption) (*RunnerOptions, error) {
+	opt := &RunnerOptions{
+		Env: make(map[string]string),
+	}
+	for _, o := range opts {
+		o(opt)
+	}
+
+	if !filepath.IsAbs(opt.toolsBinDir) {
+		return nil, fmt.Errorf("expect an absolute path for tool binaries directory, but got %q", opt.toolsBinDir)
+	}
+
+	return opt, nil
+}
+
+// WithEnv sets the runner specific environment.
+func WithEnv(env map[string]string) RunnerOption {
+	return func(o *RunnerOptions) {
+		o.Env = env
+	}
+}
+
+// WithToolsBinDir sets the path to the directory where compiled binaries of Go module-based tools are placed.
+// Defaults to DefaultToolsBinDir.
+func WithToolsBinDir(toolsBinDir string) RunnerOption {
+	return func(o *RunnerOptions) {
+		o.toolsBinDir = toolsBinDir
+	}
+}
+
+// WithQuiet indicates whether the runner output should be minimal.
+func WithQuiet(quiet bool) RunnerOption {
+	return func(o *RunnerOptions) {
+		o.Quiet = quiet
+	}
+}


### PR DESCRIPTION
Resolves #89 