### PR TITLE
`go run` support for versioned modules (Go 1.17+)

### DIFF
--- a/pkg/elder/options.go
+++ b/pkg/elder/options.go
@@ -21,9 +21,6 @@ import (
 )
 
 var (
-	// DefaultGoToolsBinDir is the default directory for compiled executables of Go module-based "main" packages.
-	DefaultGoToolsBinDir = filepath.Join(project.DefaultWandCacheDataDir, "tools", "bin")
-
 	// wandDataGitIgnoreFileName is the name for the written wandDataGitIgnoreTmpl file.
 	wandDataGitIgnoreFileName = ".gitignore"
 

--- a/pkg/task/golang/golang.go
+++ b/pkg/task/golang/golang.go
@@ -1,7 +1,11 @@
 // Copyright (c) 2019-present Sven Greb <development@svengreb.de>
 // This source code is licensed under the MIT license found in the license file.
 
+//go:build go1.17
+
 // Package golang provides Go toolchain tasks and runner.
+// Note that this package requires at least Go 1.17 due to the usage of specific Go command features and behaviors that
+// are required for tasks like [github.com/svengreb/wand/pkg/task/golang/run]!
 //
 // See https://golang.org/cmd/go for more details.
 package golang

--- a/pkg/task/golang/options.go
+++ b/pkg/task/golang/options.go
@@ -1,6 +1,8 @@
 // Copyright (c) 2019-present Sven Greb <development@svengreb.de>
 // This source code is licensed under the MIT license found in the license file.
 
+//go:build go1.17
+
 package golang
 
 import (

--- a/pkg/task/golang/run/options.go
+++ b/pkg/task/golang/run/options.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2019-present Sven Greb <development@svengreb.de>
+// This source code is licensed under the MIT license found in the license file.
+
+//go:build go1.17
+
+package run
+
+import (
+	"github.com/Masterminds/semver/v3"
+	"github.com/svengreb/wand/pkg/project"
+)
+
+const (
+	// taskName is the name of the task.
+	taskName = "go/run"
+)
+
+// Option is a task option.
+type Option func(*Options)
+
+// Options are task options.
+type Options struct {
+	// args are arguments passed to the command.
+	args []string
+	// env is the task specific environment.
+	env map[string]string
+	// goModule is the Go module identifier.
+	goModule *project.GoModuleID
+	// name is the task name.
+	name string
+}
+
+// NewOptions creates new task options.
+func NewOptions(opts ...Option) *Options {
+	opt := &Options{
+		goModule: &project.GoModuleID{},
+		name:     taskName,
+	}
+	for _, o := range opts {
+		o(opt)
+	}
+	if opt.goModule.Version == nil {
+		opt.goModule.IsLatest = true
+	}
+	return opt
+}
+
+// WithArgs sets additional arguments to pass to the command.
+func WithArgs(args ...string) Option {
+	return func(o *Options) {
+		o.args = append(o.args, args...)
+	}
+}
+
+// WithEnv sets the task specific environment.
+func WithEnv(env map[string]string) Option {
+	return func(o *Options) {
+		o.env = env
+	}
+}
+
+// WithModulePath sets the module import path.
+func WithModulePath(path string) Option {
+	return func(o *Options) {
+		if path != "" {
+			o.goModule.Path = path
+		}
+	}
+}
+
+// WithModuleVersion sets the module version.
+func WithModuleVersion(version *semver.Version) Option {
+	return func(o *Options) {
+		o.goModule.Version = version
+	}
+}

--- a/pkg/task/golang/run/run.go
+++ b/pkg/task/golang/run/run.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2019-present Sven Greb <development@svengreb.de>
+// This source code is licensed under the MIT license found in the license file.
+
+//go:build go1.17
+
+// Package run provides a task for the Go toolchain "run" command.
+// It requires at least Go version 1.17 which comes with support to [run commands in module-aware mode], by passing
+// version suffixes to `go run` arguments, without affecting the `main` module and will not "pollute" the `go.mod`
+// file.
+// See the documentation about [how to compile and run Go programs] for more details.
+//
+// [run commands in module-aware mode]: https://go.dev/doc/go1.17#go%20run
+// [how to compile and run Go programs]: https://pkg.go.dev/cmd/go#hdr-Compile_and_run_Go_program
+package run
+
+import "github.com/svengreb/wand/pkg/task"
+
+// Task is a task for the Go toolchain "run" command.
+// It requires at least Go version 1.17 which comes with support to [run commands in module-aware mode], by passing
+// version suffixes to `go run` arguments, without affecting the `main` module and will not "pollute" the `go.mod`
+// file anymore.
+// See the documentation about [how to compile and run Go programs] for more details.
+//
+// [run commands in module-aware mode]: https://go.dev/doc/go1.17#go%20run
+// [how to compile and run Go programs]: https://pkg.go.dev/cmd/go#hdr-Compile_and_run_Go_program
+type Task struct {
+	opts *Options
+}
+
+// BuildParams builds the parameters.
+// Note that configured flags are applied after the "GOFLAGS" environment variable and could overwrite already defined
+// flags.
+//
+// See the [Go command documentation about environment variables] and the builtin helps for more details:
+//
+//	go help environment
+//	go help env
+//
+// [Go command documentation about environment variables]: https://golang.org/cmd/go/#hdr-Environment_variables
+func (t *Task) BuildParams() []string {
+	params := []string{"run"}
+	params = append(params, t.opts.goModule.String())
+	params = append(params, t.opts.args...)
+	return params
+}
+
+// Env returns the task specific environment.
+func (t *Task) Env() map[string]string {
+	return t.opts.env
+}
+
+// Kind returns the task kind.
+func (t *Task) Kind() task.Kind {
+	return task.KindExec
+}
+
+// Name returns the task name.
+func (t *Task) Name() string {
+	return t.opts.name
+}
+
+// Options returns the task options.
+func (t *Task) Options() task.Options {
+	return *t.opts
+}
+
+// New creates a new task for the Go toolchain "run" command.
+func New(opts ...Option) *Task {
+	return &Task{opts: NewOptions(opts...)}
+}

--- a/pkg/task/gotool/options.go
+++ b/pkg/task/gotool/options.go
@@ -5,12 +5,22 @@ package gotool
 
 import (
 	"fmt"
+	"github.com/svengreb/wand/pkg/project"
 	"path/filepath"
 )
 
 const (
+	// DefaultWithCache is the default value that indicates whether the runner should use the cache directory that
+	// stores compiled binaries of Go module-based tools.
+	DefaultWithCache = false
+
 	// RunnerName is the name of the runner.
 	RunnerName = "gotool"
+)
+
+var (
+	// DefaultGoToolsBinDir is the default directory for compiled executables of Go module-based "main" packages.
+	DefaultGoToolsBinDir = filepath.Join(project.DefaultWandCacheDataDir, "tools", "bin")
 )
 
 // RunnerOption is a runner option.
@@ -18,6 +28,10 @@ type RunnerOption func(*RunnerOptions)
 
 // RunnerOptions are runner options.
 type RunnerOptions struct {
+	// enableCache indicates whether the runner should use the cache directory that stores compiled binaries of Go
+	// module-based tools which is defined by [WithToolsBinDir].
+	enableCache bool
+
 	// Env is the runner specific environment.
 	Env map[string]string
 
@@ -31,13 +45,14 @@ type RunnerOptions struct {
 // NewRunnerOptions creates new runner options.
 func NewRunnerOptions(opts ...RunnerOption) (*RunnerOptions, error) {
 	opt := &RunnerOptions{
-		Env: make(map[string]string),
+		enableCache: DefaultWithCache,
+		Env:         make(map[string]string),
 	}
 	for _, o := range opts {
 		o(opt)
 	}
 
-	if !filepath.IsAbs(opt.toolsBinDir) {
+	if opt.enableCache && !filepath.IsAbs(opt.toolsBinDir) {
 		return nil, fmt.Errorf("expect an absolute path for tool binaries directory, but got %q", opt.toolsBinDir)
 	}
 
@@ -56,6 +71,15 @@ func WithEnv(env map[string]string) RunnerOption {
 func WithToolsBinDir(toolsBinDir string) RunnerOption {
 	return func(o *RunnerOptions) {
 		o.toolsBinDir = toolsBinDir
+	}
+}
+
+// WithCache indicates whether the runner should use the cache directory that stores compiled binaries of Go
+// module-based tools which is defined by [WithToolsBinDir].
+// Defaults to [DefaultWithCache].
+func WithCache(withCache bool) RunnerOption {
+	return func(o *RunnerOptions) {
+		o.enableCache = withCache
 	}
 }
 


### PR DESCRIPTION
Resolves #133 